### PR TITLE
Fixed SkeletonImporter

### DIFF
--- a/ColladaXnaBase/Import/SkeletonImporter.cs
+++ b/ColladaXnaBase/Import/SkeletonImporter.cs
@@ -154,8 +154,12 @@ namespace ColladaXna.Base.Import
                 try
                 {
                     XmlNode root = xmlRoot.SelectNodes(".//node[@type='JOINT'][1]")[0];
+
                     var list = new List<XmlNode>();
-                    list.Add(root);
+
+                    if(root != null)
+                        list.Add(root);
+
                     return list;
                 }
                 catch (Exception)


### PR DESCRIPTION
According to COLLADA 1.4 standards, if I well understood, "library_controllers" is optional, "joints" are used for "skin" which is optional for "controller" (child of "library_controllers").
